### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -89,7 +89,7 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log('error');
+        alert("error");
     });
   }
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,9 @@
 $(function(){ 
+
     function buildHTML(message){
         if ( message.image ) {
-          var html = `<div class="message__date">
+          var html = `<div class="message" data-message-id="${message.id}">
+            <div class="message__date">
                 <div class="message__date__user">
                   ${message.user_name}
                 </div>
@@ -15,11 +17,12 @@ $(function(){
                 </p>
                 <img src=${message.image} >
               </div>
-            </div>`
+            </div>
+          </div>`
           return html;
         } else {
-          var html =
-           `<div class="message__date">
+          var html =`<div class="message" data-message-id="${message.id}">
+           <div class="message__date">
                 <div class="message__date__user">
                   ${message.user_name}
                 </div>
@@ -32,34 +35,64 @@ $(function(){
                   ${message.content}
                 </p>
               </div>
-            </div>`
+            </div>
+          </div>`
           return html;
         };
     }
+
     function scroll() {
         $('.chat-main__message').animate({scrollTop: $('.chat-main__message')[0].scrollHeight});
     }
 
-$('#new_message').on('submit', function(e){
-   e.preventDefault();
-   var formData = new FormData(this);
-   var url = $(this).attr('action')
-   $.ajax({
-     url: url,
-     type: "POST",
-     data: formData,
-     dataType: 'json',
-     processData: false,
-     contentType: false
-   })
-    .done(function(data){
-      var html = buildHTML(data);
-      $('.chat-main__message').append(html);      
-      $('form')[0].reset();
-      scroll();
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+      .done(function(data){
+        var html = buildHTML(data);
+        $('.chat-main__message').append(html);      
+        $('form')[0].reset();
+        scroll();
+      })
+      .fail(function() {
+          alert("メッセージ送信に失敗しました");
+      });
+  })
+
+  var reloadMessages = function() {
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.chat-main__message').append(insertHTML);
+        scroll();
+        $('form')[0].reset();
+        $(".submit-btn").prop("disabled", false);
+      }
     })
     .fail(function() {
-        alert("メッセージ送信に失敗しました");
+      console.log('error');
     });
-})
+  }
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+      setInterval(reloadMessages, 5000);
+  }
 });

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -48,7 +48,7 @@
         .message {
             padding-bottom: 46px;
             
-            .message__date {
+            &__date {
                 display: flex;
                 padding-bottom: 12px;
                 &__user {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -45,25 +45,28 @@
         padding: 35px 0 0 40px;
         overflow: scroll;
 
-        .message__date {
-            display: flex;
-            padding-bottom: 12px;
-            &__user {
-                color: #333333;
-                font-size: 16px;
-                padding-right: 10px;
-                font-weight: bold;
-            }
-            &__daytime {
-                color: #999999;
-                font-size: 12px;
-            }
-        }
-
-        &__comments {
-            color: #434A54;
-            font-size: 14px;
+        .message {
             padding-bottom: 46px;
+            
+            .message__date {
+                display: flex;
+                padding-bottom: 12px;
+                &__user {
+                    color: #333333;
+                    font-size: 16px;
+                    padding-right: 10px;
+                    font-weight: bold;
+                }
+                &__daytime {
+                    color: #999999;
+                    font-size: 12px;
+                }
+            }
+
+            .chat-main__message__comments {
+                color: #434A54;
+                font-size: 14px;
+            }
         }
     }
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+    def index
+        group = Group.find(params[:group_id])
+        last_message_id = params[:id].to_i
+        @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+      end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+    json.content message.content
+    json.image message.image.url
+    json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+    json.user_name message.user.name
+    json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,10 +1,11 @@
-%ul.message__date
-  %li.message__date__user
-    = message.user.name
-  %li.message__date__daytime
-    = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-.chat-main__message__comments
-  - if message.content.present?
-    %p.lower-message__content
-      = message.content
-  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+.message{data: {message: {id: message.id}}}
+  %ul.message__date
+    %li.message__date__user
+      = message.user.name
+    %li.message__date__daytime
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .chat-main__message__comments
+    - if message.content.present?
+      %p.lower-message__content
+        = message.content
+    = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:edit, :update, :index]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-end
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
+  end
 end


### PR DESCRIPTION
# What
チャット画面の自動更新の実装。

# Why
リロードしなければ最新のコメントが確認できないのは、リアルタイムで会話するためのチャットにおいて著しく利便性に欠けるため。リロードすればフォームにあった書きかけの文章が消えるため、書きながら最新のコメントを確認できないという欠点を補うこともできる。また、リロードよりサーバーへの負荷が少なくてすむ。